### PR TITLE
CONTRIB-4878: url escape mailto links

### DIFF
--- a/teacherview.php
+++ b/teacherview.php
@@ -669,7 +669,7 @@ if (!$students) {
             $name .= '</a>';
             if (scheduler_has_slot($student->id, $scheduler, true, false) == 0){
                 // student has never scheduled
-                $mailto .= $student->email.', ';
+                $mailto .= $student->email.',%20';
                 $maillist[] = $student->email; // constructing list of email addresses to be shown later
             }
 
@@ -714,7 +714,7 @@ if (!$students) {
         // Print links to print invitation or reminder emails
         $strinvitation = get_string('invitation', 'scheduler');
         $strreminder = get_string('reminder', 'scheduler');
-        $mailto = rtrim($mailto, ', ');
+        $mailto = rtrim($mailto, ',%20');
 
         $subject = $strinvitation . ': ' . $scheduler->name;
         $body = $strinvitation . ': ' . $scheduler->name . "\n\n";


### PR DESCRIPTION
https://tracker.moodle.org/browse/CONTRIB-4878

The teacher view page fails to url escape spaces in the mailto link. This prevents teachers with Apple Mail from using the mailto links.
