### PR TITLE
Added delete confirmation for individual slots

### DIFF
--- a/lang/en/scheduler.php
+++ b/lang/en/scheduler.php
@@ -123,6 +123,7 @@ $string['date'] = 'Date';
 $string['datelist'] = 'Overview';
 $string['defaultslotduration'] = 'Default slot duration';
 $string['defaultslotduration_help'] = 'The default length (in minutes) for appointment slots that you set up';
+$string['deleteslotconfirm'] = 'Delete slot?';
 $string['deleteallslots'] = 'Delete all slots';
 $string['deleteallunusedslots'] = 'Delete unused slots';
 $string['deletecommands'] = 'Delete slots';

--- a/renderer.php
+++ b/renderer.php
@@ -568,7 +568,8 @@ class mod_scheduler_renderer extends plugin_renderer_base {
             $actions = '';
             if ($slot->editable) {
                 $url = new moodle_url($slotman->actionurl, array('what' => 'deleteslot', 'slotid' => $slot->slotid));
-                $actions .= $this->action_icon($url, new pix_icon('t/delete', get_string('delete')));
+				$confirmdelete = new confirm_action(get_string('deleteslotconfirm', 'scheduler'));
+                $actions .= $this->action_icon($url, new pix_icon('t/delete', get_string('delete')), $confirmdelete);
 
                 $url = new moodle_url($slotman->actionurl, array('what' => 'updateslot', 'slotid' => $slot->slotid));
                 $actions .= $this->action_icon($url, new pix_icon('t/edit', get_string('edit')));


### PR DESCRIPTION
When individual slots are deleted using the 'x' icon, they are deleted immediately with confirmation. This adds a delete confirmation alert box.