### PR TITLE
Fix call to deprecated class. (Renamed in 3.3)

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -19,5 +19,5 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright  2016 Henning Bostelmann and others (see README.txt)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class activity extends \core_search\area\base_activity {
+class activity extends \core_search\base_activity {
 }


### PR DESCRIPTION
fixes failure in tests:

search_manager_testcase::test_search_areas
Unexpected debugging() call detected.
Debugging: Class 'core_search\area\base_activity' has been renamed for the autoloader and is now deprecated. Please use 'core_search\base_activity' instead.