### PR TITLE
Added support for block_myoverview in Moodle 3.3+

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -54,8 +54,10 @@ function scheduler_add_instance($data, $mform = null) {
 
     scheduler_grade_item_update($data);
 
-    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
-    \core_completion\api::update_completion_date_event($data->coursemodule, 'scheduler', $data->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
+        \core_completion\api::update_completion_date_event($data->coursemodule, 'scheduler', $data->id, $completiontimeexpected);
+    }
 
     return $data->id;
 }
@@ -86,8 +88,10 @@ function scheduler_update_instance($data, $mform) {
     // Update grade item and grades.
     scheduler_update_grades($data);
 
-    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
-    \core_completion\api::update_completion_date_event($data->coursemodule, 'scheduler', $data->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
+        \core_completion\api::update_completion_date_event($data->coursemodule, 'scheduler', $data->id, $completiontimeexpected);
+    }
 
     return true;
 }


### PR DESCRIPTION
cf. https://docs.moodle.org/dev/Calendar_API#Action_events

According to Moodle 3.3 documentation, the new Course Overview block displays notifications in My Page when a teacher sets an 'Expect completed on' date in the activity completion settings. This works will core modules and should work consistently with 3rd-party modules as well.

see https://docs.moodle.org/33/en/Course_overview 

The proposed changes would implement this in mod_scheduler