### PR TITLE
Allow the gradesneedregrading exception in scheduler_instance as it can break course reset

### DIFF
--- a/model/scheduler_instance.php
+++ b/model/scheduler_instance.php
@@ -476,13 +476,20 @@ class scheduler_instance extends mvc_record_model {
             }
         } else {
             $gui = new graded_users_iterator($this->get_courserec());
-            $gui->init();
-            while ($userdata = $gui->next_user()) {
-                $uid = $userdata->user->id;
-                if (!array_key_exists($uid, $finalgrades)) {
-                    $finalgrades[$uid] = new stdClass();
-                    $finalgrades[$uid]->userid = $uid;
-                    $finalgrades[$uid]->rawgrade = null;
+            // We must gracefully live through the gradesneedregrading that can be thrown by init()
+            try {
+                $gui->init();
+                while ($userdata = $gui->next_user()) {
+                    $uid = $userdata->user->id;
+                    if (!array_key_exists($uid, $finalgrades)) {
+                        $finalgrades[$uid] = new stdClass();
+                        $finalgrades[$uid]->userid = $uid;
+                        $finalgrades[$uid]->rawgrade = null;
+                    }
+                }
+            } catch (\moodle_exception $e) {
+                if ($e->errorcode != 'gradesneedregrading') {
+                   throw $e;
                 }
             }
         }


### PR DESCRIPTION
I don't really (yet) have a good scenario for this; but I have instances of course reset that fail:
* [`reset_course_userdata($data)`](https://github.com/moodle/moodle/blob/master/lib/moodlelib.php#L5375)
* `…`
* [`grade_update_mod_grades($modinstance, $userid)`](https://github.com/moodle/moodle/blob/master/lib/gradelib.php#L1381)
* [`scheduler_update_grades($schedulerrecord, $userid, $nullifnone)`](https://github.com/bostelm/moodle-mod_scheduler/blob/master/lib.php#L367)

At this point, a `gradesneedregrading` can be thrown by [`graded_users_iterator::init()`](https://github.com/moodle/moodle/blob/master/grade/lib.php#L133), specifically with the [line 138](https://github.com/moodle/moodle/blob/175b3708c92f3f19529ccab62dcc196c46ba6423/grade/lib.php#L138):
```
        export_verify_grades($this->course->id);
```

My proposal is to catch and discard this specific `\moodle_exception`, to let the reset go through.