### PR TITLE
Fix: Multiple records found if same name of instance exists

### DIFF
--- a/classes/model/scheduler.php
+++ b/classes/model/scheduler.php
@@ -86,8 +86,8 @@ class scheduler extends mvc_record_model {
      * @return scheduler
      */
     public static function load_by_id($id) {
-        global $DB;
-        $cm = get_coursemodule_from_instance('scheduler', $id, 0, false, MUST_EXIST);
+        global $COURSE;
+        $cm = get_coursemodule_from_instance('scheduler', $id, $COURSE->id, false, MUST_EXIST);
         return self::load_from_record($id, $cm);
     }
 

--- a/lib.php
+++ b/lib.php
@@ -437,7 +437,7 @@ function scheduler_grade_item_update($scheduler, $grades=null) {
         $scheduler->courseid = $scheduler->course;
     }
     $moduleid = $DB->get_field('modules', 'id', array('name' => 'scheduler'));
-    $cmid = $DB->get_field('course_modules', 'id', array('module' => $moduleid, 'instance' => $scheduler->id));
+    $cmid = $DB->get_field('course_modules', 'id', array('course' => $scheduler->courseid, 'module' => $moduleid, 'instance' => $scheduler->id));
 
     if ($scheduler->scale == 0) {
         // Delete any grade item.


### PR DESCRIPTION
Hi  @bostelm 

We're encountering a problem if the activity exists with the same name in another course. We're testing the plugin on a `Moodle 3.9dev+ (Build: 20200522)` environment - please be aware.

But nevertheless it would be better to add the `courseid` to these methods, to get better results.

Request-URL: https://FQDN/mod/scheduler/view.php?id=INSTANCEID&subpage=allappointments&offset=-1&what=revokeall&sesskey=SESSKEY&slotid=SLOTID

Result:
```php
Multiple records found, only one record expected.

More information about this error

Debug info: SELECT cm.*, m.name, md.name AS modname
FROM {course_modules} cm
JOIN {modules} md ON md.id = cm.module
JOIN {scheduler} m ON m.id = cm.instance

WHERE m.id = :instance AND md.name = :modulename

[array (
'instance' => '29',
'modulename' => 'scheduler',
)]

Error code: multiplerecordsfound
×Stack trace:
line 1634 of /lib/dml/moodle_database.php: dml_multiple_records_exception thrown
line 1281 of /lib/datalib.php: call to moodle_database->get_record_sql()
line 90 of /mod/scheduler/classes/model/scheduler.php: call to get_coursemodule_from_instance()
line 406 of /mod/scheduler/lib.php: call to mod_scheduler\model\scheduler::load_by_id()
line 81 of /mod/scheduler/classes/model/appointment.php: call to scheduler_update_grades()
line 178 of /mod/scheduler/classes/model/mvc_child_list.php: call to mod_scheduler\model\appointment->delete()
line 84 of /mod/scheduler/classes/model/slot.php: call to mod_scheduler\model\mvc_child_list->save_children()
line 289 of /mod/scheduler/teacherview.controller.php: call to mod_scheduler\model\slot->save()
line 141 of /mod/scheduler/teacherview.php: call to require_once()
line 88 of /mod/scheduler/view.php: call to include()
```

HTH,
Adrian