### PR TITLE
Add time component to slot's hideuntil setting

### DIFF
--- a/slotforms.php
+++ b/slotforms.php
@@ -229,7 +229,7 @@ class scheduler_editslot_form extends scheduler_slotform_base {
         $this->add_base_fields();
 
         // Display slot from this date.
-        $mform->addElement('date_selector', 'hideuntil', get_string('displayfrom', 'scheduler'));
+        $mform->addElement('date_time_selector', 'hideuntil', get_string('displayfrom', 'scheduler'));
         $mform->setDefault('hideuntil', time());
 
         // Send e-mail reminder?


### PR DESCRIPTION
Changed _hideuntil_ setting to include time component. This is a _one liner_.

Currently we are not able to be more precise when exactly a slot should be visible to students. Especially in situation with multiple slots within a same day. Students will see all slots at once at 00:00 and book them immediately. To prevent that and introduce "fair booking" a time component should be used.