### PR TITLE
Fix attachments not viewable

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -719,7 +719,8 @@ function scheduler_pluginfile($course, $cm, $context, $filearea, $args, $forcedo
     $fullpath = "/$context->id/mod_scheduler/$filearea/$entryid/$relativepath";
 
     $fs = get_file_storage();
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         return false;
     }
 


### PR DESCRIPTION
The `pluginfile` function broke because of [this Code-Style change in lib.php:721](https://github.com/bostelm/moodle-mod_scheduler/pull/48/files#diff-8f5ff72ef1cf59199cfc4bbf16f2475d09e448601242f0d2c51bb94bd4aa1395R721) in #48.

`or` has a lower [operator precedence](https://www.php.net/manual/en/language.operators.precedence.php) than `=`, but `||` has a higher one, meaning `$file` will be set to `true` instead of the `stored_file` object, causing 
```
Error: Call to a member function is\_external\_file() on bool

**Stack trace:** 
*   line 2726 of /lib/filelib.php: Error thrown
*   line 726 of /mod/scheduler/lib.php: call to send\_stored\_file()
*   line 5212 of /lib/filelib.php: call to scheduler\_pluginfile()
*   line 44 of /pluginfile.php: call to file\_pluginfile()
```

I put the statement on a separate line because I thought it looked a bit nicer than using parenthesis.

As reference:
![image](https://user-images.githubusercontent.com/45795270/228863267-85a4acb0-f20d-4278-8027-c7774896073f.png)


Cheers
Justus :)