### PR TITLE
Prevent export crash due to missing user context

### DIFF
--- a/exportlib.php
+++ b/exportlib.php
@@ -659,7 +659,8 @@ class scheduler_profile_field extends scheduler_export_field {
      * @return string the value of this field for the given data
      */
     public function get_value(slot $slot, $appointment) {
-        if (!$appointment instanceof appointment || $appointment->studentid == 0) {
+        if (!$appointment instanceof appointment || $appointment->studentid == 0
+        || !context_user::instance($appointment->studentid, IGNORE_MISSING)) {
             return '';
         }
         $this->field->set_userid($appointment->studentid);


### PR DESCRIPTION
After user data removal by tool_dataprivacy
`tool_dataprivacy\task\expired_retention_period` is used to remove user contexts

When exporting appointments with custom profile field selected this lead to a crash.
This is due to profile field visibility check using `profile_field_base::is_visible()` which is calling `context_user::instance()` with default strictness (`MUST_EXIST`)...leading to an exception when the context is removed.