### PR TITLE
Dynamic properties deprecated

### DIFF
--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -87,6 +87,11 @@ class privacy_test extends provider_testcase {
      */
     protected $allstudents;
 
+    /**
+     * @var array all appointment ids involved in the scheduler
+     */
+    protected $appointmentids;
+
     protected function setUp(): void {
         global $DB, $CFG;
 

--- a/tests/scheduler_test.php
+++ b/tests/scheduler_test.php
@@ -62,6 +62,11 @@ class scheduler_test extends \advanced_testcase {
      */
     protected $slotid;
 
+    /**
+     * @var array all appointment ids involved in the scheduler
+     */
+    protected $appointmentids;
+
     protected function setUp(): void {
         global $DB, $CFG;
 


### PR DESCRIPTION
In PHP 8.2 dynamic properties are deprecated. 

Using $this->appointmentids without declaring generate 13 warnings (and 13 risky tests in phpunit).