### PR TITLE
CONTRIB-9504 Fix Undefined constant "viewurl"

### DIFF
--- a/teacherview.php
+++ b/teacherview.php
@@ -148,7 +148,7 @@ if ($action == 'addslot') {
     $actionurl = new moodle_url($baseurl, array('what' => 'addslot'));
 
     if (!$scheduler->has_available_teachers()) {
-        throw new moodle_exception('needteachers', 'scheduler', viewurl);
+        throw new moodle_exception('needteachers', 'scheduler', $viewurl);
     }
 
     $mform = new scheduler_editslot_form($actionurl, $scheduler, $cm, $groupsicansee);


### PR DESCRIPTION
Attempting to add a slot on a course with no teachers resulted in:
  Exception - Undefined constant "viewurl"
instead of the expected:
  Slots cannot be added as this course has no teachers