### PR TITLE
Fixed "Undefined constant viewurl" in PHP 8.0

### DIFF
--- a/teacherview.php
+++ b/teacherview.php
@@ -148,7 +148,7 @@ if ($action == 'addslot') {
     $actionurl = new moodle_url($baseurl, array('what' => 'addslot'));
 
     if (!$scheduler->has_available_teachers()) {
-        throw new moodle_exception('needteachers', 'scheduler', viewurl);
+        throw new moodle_exception('needteachers', 'scheduler', $viewurl);
     }
 
     $mform = new scheduler_editslot_form($actionurl, $scheduler, $cm, $groupsicansee);


### PR DESCRIPTION
This gives a 'Undefined constant'. PHP 8+ is more strict. I have not checked the rest of the module.

Fixes:
![image](https://github.com/user-attachments/assets/b9dbdd9b-8f73-4fc9-af4c-eead45bc78ca)
